### PR TITLE
Remove incorrect vec3 import

### DIFF
--- a/scripts/utils/vec3_conversion.py
+++ b/scripts/utils/vec3_conversion.py
@@ -1,6 +1,3 @@
-import vec3
-
-
 def vec3_to_str(v):
     return f"x: {v['x']:.3f}, y: {v['y']:.3f}, z: {v['z']:.3f}"
 


### PR DESCRIPTION
The [vec3](https://pypi.org/project/vec3) python package isn't the same one that mineflayer uses and isn't used in this file anyway so should probably be removed